### PR TITLE
use unstylized platform value tandem-x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## Changed
+
+- Item `platform` value from `TanDEM-X` to `tandem-x` ([#15](https://github.com/stactools-packages/cop-dem/pull/15))
+
 ## [0.1.1] - 2023-01-30
 
 ### Added

--- a/examples/cop-dem-glo-30/Copernicus_DSM_COG_10_N53_00_W115_00_DEM/Copernicus_DSM_COG_10_N53_00_W115_00_DEM.json
+++ b/examples/cop-dem-glo-30/Copernicus_DSM_COG_10_N53_00_W115_00_DEM/Copernicus_DSM_COG_10_N53_00_W115_00_DEM.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "Copernicus_DSM_COG_10_N53_00_W115_00_DEM",
   "properties": {
-    "platform": "TanDEM-X",
+    "platform": "tandem-x",
     "gsd": 30,
     "providers": [
       {

--- a/examples/cop-dem-glo-30/collection.json
+++ b/examples/cop-dem-glo-30/collection.json
@@ -91,7 +91,7 @@
       30
     ],
     "platform": [
-      "TanDEM-X"
+      "tandem-x"
     ]
   }
 }

--- a/examples/cop-dem-glo-90/Copernicus_DSM_COG_30_N53_00_W115_00_DEM/Copernicus_DSM_COG_30_N53_00_W115_00_DEM.json
+++ b/examples/cop-dem-glo-90/Copernicus_DSM_COG_30_N53_00_W115_00_DEM/Copernicus_DSM_COG_30_N53_00_W115_00_DEM.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "Copernicus_DSM_COG_30_N53_00_W115_00_DEM",
   "properties": {
-    "platform": "TanDEM-X",
+    "platform": "tandem-x",
     "gsd": 90,
     "providers": [
       {

--- a/examples/cop-dem-glo-90/collection.json
+++ b/examples/cop-dem-glo-90/collection.json
@@ -91,7 +91,7 @@
       90
     ],
     "platform": [
-      "TanDEM-X"
+      "tandem-x"
     ]
   }
 }

--- a/src/stactools/cop_dem/constants.py
+++ b/src/stactools/cop_dem/constants.py
@@ -14,7 +14,7 @@ COP_DEM_COLLECTION_END: Optional[datetime] = str_to_datetime(
     "2021-04-22T00:00:00Z")
 COP_DEM_TEMPORAL_EXTENT = [COP_DEM_COLLECTION_START,
                            COP_DEM_COLLECTION_END]  # TODO: find the dates
-COP_DEM_PLATFORM = "TanDEM-X"
+COP_DEM_PLATFORM = "tandem-x"
 COP_DEM_EPSG = 4326
 COP_DEM_KEYWORDS = ['DEM', 'COPERNICUS', 'DSM', 'Elevation']
 COP_DEM_PROVIDERS = [

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -31,7 +31,7 @@ class StacTest(TestCase):
             datetime.datetime(2021, 4, 22, tzinfo=datetime.timezone.utc))
 
         common_metadata = item.common_metadata
-        self.assertEqual(common_metadata.platform, "TanDEM-X")
+        self.assertEqual(common_metadata.platform, "tandem-x")
         self.assertEqual(common_metadata.gsd, 30)
         expected_providers = [
             Provider("European Space Agency",
@@ -90,7 +90,7 @@ class StacTest(TestCase):
             datetime.datetime(2021, 4, 22, tzinfo=datetime.timezone.utc))
 
         common_metadata = item.common_metadata
-        self.assertEqual(common_metadata.platform, "TanDEM-X")
+        self.assertEqual(common_metadata.platform, "tandem-x")
         self.assertEqual(common_metadata.gsd, 90)
         expected_providers = [
             Provider("European Space Agency",


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stactools-packages/cop-dem/issues/14

**Description:**

STAC spec recommends using lower-kebab-case values for the `platform` field. 

This PR changes the value used for cop-dem from `TanDEM-X` to `tandem-x`

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
