### PR TITLE
add raster extension advertisement to item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 
 - Fixed license link to a valid URL ([#17](https://github.com/stactools-packages/cop-dem/pull/17))
+- Item now propertly advertises use of the Raster Extension via stac_extensions ([#18](https://github.com/stactools-packages/cop-dem/pull/18))
 
 ## [0.1.1] - 2023-01-30
 

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -85,8 +85,9 @@ def create_item(href: str,
                                    data_type=DataType.FLOAT32,
                                    spatial_resolution=gsd,
                                    unit="meter")
-    RasterExtension.ext(data_asset).bands = [data_bands]
+
     item.add_asset("data", data_asset)
+    RasterExtension.ext(data_asset, add_if_missing=True).bands = [data_bands]
 
     projection = ProjectionExtension.ext(item, add_if_missing=True)
     projection.epsg = co.COP_DEM_EPSG

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -78,10 +78,10 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
-        ProjectionExtension.validate_has_extension(item, add_if_missing=False)
-        RasterExtension.validate_has_extension(item, add_if_missing=False)
+        self.assertTrue(ProjectionExtension.has_extension(item))
+        self.assertTrue(RasterExtension.has_extension(item))
 
-        item.validate()
+        item.validate() # raises STACValidationError if not
 
     def test_create_glo90_item(self):
         item = stac.create_item(self.glo90_path)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -77,10 +77,8 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
-        self.assertCountEqual(item.stac_extensions, [
-            pystac.extensions.projection.SCHEMA_URI,
-            pystac.extensions.raster.SCHEMA_URI,
-        ])
+        ProjectionExtension.validate_has_extension(item)
+        RasterExtension.validate_has_extension(item)
 
         item.validate()
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import TestCase
 
+import pystac
 from pystac import Provider, MediaType
 from pystac.extensions.projection import ProjectionExtension
 from pystac.provider import ProviderRole
@@ -76,6 +77,11 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
+        self.assertCountEqual(item.stac_extensions, [
+            pystac.extensions.projection.SCHEMA_URI,
+            pystac.extensions.raster.SCHEMA_URI,
+        ])
+
         item.validate()
 
     def test_create_glo90_item(self):
@@ -134,6 +140,11 @@ class StacTest(TestCase):
         self.assertIsNone(data.description)
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
+
+        self.assertCountEqual(item.stac_extensions, [
+            pystac.extensions.projection.SCHEMA_URI,
+            pystac.extensions.raster.SCHEMA_URI,
+        ])
 
         item.validate()
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -140,12 +140,10 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
-        self.assertCountEqual(item.stac_extensions, [
-            pystac.extensions.projection.SCHEMA_URI,
-            pystac.extensions.raster.SCHEMA_URI,
-        ])
+        self.assertTrue(ProjectionExtension.has_extension(item))
+        self.assertTrue(RasterExtension.has_extension(item))
 
-        item.validate()
+        item.validate() # raises STACValidationError if not
 
     def test_create_item_with_read_href_modifier(self):
         done = False

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,7 +1,6 @@
 import datetime
 from unittest import TestCase
 
-import pystac
 from pystac import Provider, MediaType
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.raster import RasterExtension
@@ -81,7 +80,7 @@ class StacTest(TestCase):
         self.assertTrue(ProjectionExtension.has_extension(item))
         self.assertTrue(RasterExtension.has_extension(item))
 
-        item.validate() # raises STACValidationError if not
+        item.validate()  # raises STACValidationError if not
 
     def test_create_glo90_item(self):
         item = stac.create_item(self.glo90_path)
@@ -143,7 +142,7 @@ class StacTest(TestCase):
         self.assertTrue(ProjectionExtension.has_extension(item))
         self.assertTrue(RasterExtension.has_extension(item))
 
-        item.validate() # raises STACValidationError if not
+        item.validate()  # raises STACValidationError if not
 
     def test_create_item_with_read_href_modifier(self):
         done = False

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 import pystac
 from pystac import Provider, MediaType
 from pystac.extensions.projection import ProjectionExtension
+from pystac.extensions.raster import RasterExtension
 from pystac.provider import ProviderRole
 
 from stactools.cop_dem import stac
@@ -77,8 +78,8 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
-        ProjectionExtension.validate_has_extension(item)
-        RasterExtension.validate_has_extension(item)
+        ProjectionExtension.validate_has_extension(item, add_if_missing=False)
+        RasterExtension.validate_has_extension(item, add_if_missing=False)
 
         item.validate()
 


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stactools-packages/cop-dem/issues/13

**Description:**

The Raster Extension is used in Item, but the code constructs it without the flag that adds it to the Item's stac_extensions list. This fixes that, so it is properly advertised.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
