### PR TITLE
fix asset title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## [Unreleased] - TBD
+
+## Changed
+
+- The asset title is now always `Data`, rather than being specific to each item derived from the item ID. ([#21](https://github.com/stactools-packages/cop-dem/pull/21))
+
 ## [0.2.0] - 2023-03-24
 
 ## Changed

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -45,7 +45,8 @@ def create_item(href: str,
                     properties={},
                     stac_extensions=[])
 
-    p = re.compile(r'Copernicus_DSM_COG_(\d\d)_(.*)_DEM.tif')
+    # resolution in arc seconds (not meters!), which is and 30 for GLO-90 and 10 for GLO-30
+    p = re.compile(r'Copernicus_DSM_COG_(\d\d)_.*')
     m = p.match(os.path.basename(href))
     if m:
         if m.group(1) == '30':
@@ -54,7 +55,6 @@ def create_item(href: str,
             gsd = 30
         else:
             raise ValueError("unknown resolution {}".format(m.group(1)))
-        title = m.group(2)
     else:
         raise ValueError("unable to parse {}".format(href))
 
@@ -76,7 +76,7 @@ def create_item(href: str,
 
     data_asset = Asset(
         href=href,
-        title=title,
+        title="Data",
         description=None,
         media_type=MediaType.COG,
         roles=["data"],

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -72,7 +72,7 @@ class StacTest(TestCase):
 
         data = item.assets["data"]
         self.assertEqual(data.href, self.glo30_path)
-        self.assertEqual(data.title, "N53_00_W115_00")
+        self.assertEqual(data.title, "Data")
         self.assertIsNone(data.description)
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
@@ -134,7 +134,7 @@ class StacTest(TestCase):
 
         data = item.assets["data"]
         self.assertEqual(data.href, self.glo90_path)
-        self.assertEqual(data.title, "N53_00_W115_00")
+        self.assertEqual(data.title, "Data")
         self.assertIsNone(data.description)
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])


### PR DESCRIPTION
**Related Issue(s):**
n/a

**Description:**

The asset title should be consistent across all items, rather than specific to the item is in. This changes the asset title from being derived from the item id to always being `Data`

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
