### PR TITLE
add Grid Extension support with grid:code field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## [Unreleased] - TBD
+
+## Added
+
+- Added support for Grid Extension with property `grid:code` ([#24](https://github.com/stactools-packages/cop-dem/pull/24))
+
 ## [0.3.0] - 2023-03-27
 
 ## Changed

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -114,7 +114,7 @@ def create_item(
     projection.shape = shape
 
     grid = GridExtension.ext(item, add_if_missing=True)
-    grid.code = f"CDEM-{res}{northing}{easting}"
+    grid.code = f"CDEM-{northing}{easting}"
 
     return item
 

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -42,10 +42,8 @@ def create_item(
         modified_href = href
     with rasterio.open(modified_href) as dataset:
         if dataset.crs.to_epsg() != co.COP_DEM_EPSG:
-            raise ValueError(
-                f"Dataset {href} is not EPSG:{co.COP_DEM_EPSG}, "
-                "which is required for Copernicus DEM data"
-            )
+            raise ValueError(f"Dataset {href} is not EPSG:{co.COP_DEM_EPSG}, "
+                             "which is required for Copernicus DEM data")
         bbox = list(dataset.bounds)
         geometry = mapping(box(*bbox))
         transform = dataset.transform
@@ -61,7 +59,7 @@ def create_item(
 
     # resolution in arc seconds (not meters!), which is and 30 for GLO-90 and 10 for GLO-30
     p = re.compile(
-        r"Copernicus_DSM_COG_(?P<res>\d{2})_(?P<northing>[NS]\d{2})_00_(?P<easting>[EW]\d{3})_00_DEM.*"
+        r"Copernicus_DSM_COG_(?P<res>\d{2})_(?P<northing>[NS]\d{2})_00_(?P<easting>[EW]\d{3})_00_DEM.*"  # noqa: E501
     )
     if m := p.match(os.path.basename(href)):
         res = m.group("res")

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -2,8 +2,16 @@ import os.path
 import re
 from typing import Optional
 
-from pystac import (CatalogType, Collection, Extent, Asset, Summaries,
-                    SpatialExtent, TemporalExtent)
+from pystac import (
+    CatalogType,
+    Collection,
+    Extent,
+    Asset,
+    Summaries,
+    SpatialExtent,
+    TemporalExtent,
+)
+from pystac.extensions.grid import GridExtension
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.item_assets import ItemAssetsExtension
 from pystac.extensions.raster import (
@@ -22,9 +30,11 @@ from stactools.core.io import ReadHrefModifier
 from stactools.cop_dem import constants as co
 
 
-def create_item(href: str,
-                read_href_modifier: Optional[ReadHrefModifier] = None,
-                host: Optional[str] = None) -> Item:
+def create_item(
+    href: str,
+    read_href_modifier: Optional[ReadHrefModifier] = None,
+    host: Optional[str] = None,
+) -> Item:
     """Creates a STAC Item from a single tile of Copernicus DEM data."""
     if read_href_modifier:
         modified_href = read_href_modifier(href)
@@ -32,31 +42,40 @@ def create_item(href: str,
         modified_href = href
     with rasterio.open(modified_href) as dataset:
         if dataset.crs.to_epsg() != co.COP_DEM_EPSG:
-            raise ValueError(f"Dataset {href} is not EPSG:{co.COP_DEM_EPSG}, "
-                             "which is required for Copernicus DEM data")
+            raise ValueError(
+                f"Dataset {href} is not EPSG:{co.COP_DEM_EPSG}, "
+                "which is required for Copernicus DEM data"
+            )
         bbox = list(dataset.bounds)
         geometry = mapping(box(*bbox))
         transform = dataset.transform
         shape = dataset.shape
-        item = Item(id=os.path.splitext(os.path.basename(href))[0],
-                    geometry=geometry,
-                    bbox=bbox,
-                    datetime=co.COP_DEM_COLLECTION_START,
-                    properties={},
-                    stac_extensions=[])
+        item = Item(
+            id=os.path.splitext(os.path.basename(href))[0],
+            geometry=geometry,
+            bbox=bbox,
+            datetime=co.COP_DEM_COLLECTION_START,
+            properties={},
+            stac_extensions=[],
+        )
 
     # resolution in arc seconds (not meters!), which is and 30 for GLO-90 and 10 for GLO-30
-    p = re.compile(r'Copernicus_DSM_COG_(\d\d)_.*')
-    m = p.match(os.path.basename(href))
-    if m:
-        if m.group(1) == '30':
+    p = re.compile(
+        r"Copernicus_DSM_COG_(?P<res>\d{2})_(?P<northing>[NS]\d{2})_00_(?P<easting>[EW]\d{3})_00_DEM.*"
+    )
+    if m := p.match(os.path.basename(href)):
+        res = m.group("res")
+        if res == "30":
             gsd = 90
-        elif m.group(1) == '10':
+        elif res == "10":
             gsd = 30
         else:
-            raise ValueError("unknown resolution {}".format(m.group(1)))
+            raise ValueError(f"unknown resolution {res}")
+
+        northing = m.group("northing")
+        easting = m.group("easting")
     else:
-        raise ValueError("unable to parse {}".format(href))
+        raise ValueError(f"unable to parse {href}")
 
     item.add_links(co.COP_DEM_LINKS)
     item.common_metadata.platform = co.COP_DEM_PLATFORM
@@ -81,10 +100,12 @@ def create_item(href: str,
         media_type=MediaType.COG,
         roles=["data"],
     )
-    data_bands = RasterBand.create(sampling=Sampling.POINT,
-                                   data_type=DataType.FLOAT32,
-                                   spatial_resolution=gsd,
-                                   unit="meter")
+    data_bands = RasterBand.create(
+        sampling=Sampling.POINT,
+        data_type=DataType.FLOAT32,
+        spatial_resolution=gsd,
+        unit="meter",
+    )
 
     item.add_asset("data", data_asset)
     RasterExtension.ext(data_asset, add_if_missing=True).bands = [data_bands]
@@ -93,6 +114,9 @@ def create_item(href: str,
     projection.epsg = co.COP_DEM_EPSG
     projection.transform = transform[0:6]
     projection.shape = shape
+
+    grid = GridExtension.ext(item, add_if_missing=True)
+    grid.code = f"CDEM-{res}{northing}{easting}"
 
     return item
 
@@ -142,22 +166,25 @@ def create_collection(product: str, host: Optional[str] = None) -> Collection:
     else:
         providers = co.COP_DEM_PROVIDERS
 
-    collection = Collection(id=f"cop-dem-{product.lower()}",
-                            title=f"Copernicus DEM {product.upper()}",
-                            description=co.COP_DEM_DESCRIPTION,
-                            license="proprietary",
-                            keywords=co.COP_DEM_KEYWORDS,
-                            catalog_type=CatalogType.RELATIVE_PUBLISHED,
-                            summaries=Summaries(summaries),
-                            extent=Extent(
-                                SpatialExtent(co.COP_DEM_SPATIAL_EXTENT),
-                                TemporalExtent([co.COP_DEM_TEMPORAL_EXTENT])),
-                            providers=providers,
-                            stac_extensions=[
-                                ItemAssetsExtension.get_schema_uri(),
-                                ProjectionExtension.get_schema_uri(),
-                                RasterExtension.get_schema_uri(),
-                            ])
+    collection = Collection(
+        id=f"cop-dem-{product.lower()}",
+        title=f"Copernicus DEM {product.upper()}",
+        description=co.COP_DEM_DESCRIPTION,
+        license="proprietary",
+        keywords=co.COP_DEM_KEYWORDS,
+        catalog_type=CatalogType.RELATIVE_PUBLISHED,
+        summaries=Summaries(summaries),
+        extent=Extent(
+            SpatialExtent(co.COP_DEM_SPATIAL_EXTENT),
+            TemporalExtent([co.COP_DEM_TEMPORAL_EXTENT]),
+        ),
+        providers=providers,
+        stac_extensions=[
+            ItemAssetsExtension.get_schema_uri(),
+            ProjectionExtension.get_schema_uri(),
+            RasterExtension.get_schema_uri(),
+        ],
+    )
 
     collection.add_links(co.COP_DEM_LINKS)
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import TestCase
 
 from pystac import Provider, MediaType
+from pystac.extensions.grid import GridExtension
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.raster import RasterExtension
 from pystac.provider import ProviderRole
@@ -60,6 +61,10 @@ class StacTest(TestCase):
             -0.0002777777777777778, 54.00013888888889
         ])
 
+
+        grid = GridExtension.ext(item)
+        self.assertEqual(grid.code, "CDEM-10N53W115")
+
         handbook = item.get_single_link("handbook")
         self.assertIsNotNone(handbook)
         self.assertEqual(handbook.title, "Copernicus DEM User handbook")
@@ -77,6 +82,7 @@ class StacTest(TestCase):
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])
 
+        self.assertTrue(GridExtension.has_extension(item))
         self.assertTrue(ProjectionExtension.has_extension(item))
         self.assertTrue(RasterExtension.has_extension(item))
 
@@ -121,6 +127,9 @@ class StacTest(TestCase):
             0.00125, 0.0, -115.000625, 0.0, -0.0008333333333333334,
             54.000416666666666
         ])
+        
+        grid = GridExtension.ext(item)
+        self.assertEqual(grid.code, "CDEM-30N53W115")
 
         handbook = item.get_single_link("handbook")
         self.assertIsNotNone(handbook)
@@ -141,6 +150,7 @@ class StacTest(TestCase):
 
         self.assertTrue(ProjectionExtension.has_extension(item))
         self.assertTrue(RasterExtension.has_extension(item))
+        self.assertTrue(GridExtension.has_extension(item))
 
         item.validate()  # raises STACValidationError if not
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -61,7 +61,6 @@ class StacTest(TestCase):
             -0.0002777777777777778, 54.00013888888889
         ])
 
-
         grid = GridExtension.ext(item)
         self.assertEqual(grid.code, "CDEM-10N53W115")
 
@@ -127,7 +126,7 @@ class StacTest(TestCase):
             0.00125, 0.0, -115.000625, 0.0, -0.0008333333333333334,
             54.000416666666666
         ])
-        
+
         grid = GridExtension.ext(item)
         self.assertEqual(grid.code, "CDEM-30N53W115")
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -62,7 +62,7 @@ class StacTest(TestCase):
         ])
 
         grid = GridExtension.ext(item)
-        self.assertEqual(grid.code, "CDEM-10N53W115")
+        self.assertEqual(grid.code, "CDEM-N53W115")
 
         handbook = item.get_single_link("handbook")
         self.assertIsNotNone(handbook)
@@ -128,7 +128,7 @@ class StacTest(TestCase):
         ])
 
         grid = GridExtension.ext(item)
-        self.assertEqual(grid.code, "CDEM-30N53W115")
+        self.assertEqual(grid.code, "CDEM-N53W115")
 
         handbook = item.get_single_link("handbook")
         self.assertIsNotNone(handbook)


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

Add Grid Extension support with grid:code field.

Description of CDEM grid is in PR:

- https://github.com/stac-extensions/grid/pull/7

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
