### PR TITLE
add projection extension centroid field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Added
 
 - Added support for Grid Extension with property `grid:code` ([#24](https://github.com/stactools-packages/cop-dem/pull/24))
+- Added Projection Extension property `proj:centroid` ([#26](https://github.com/stactools-packages/cop-dem/pull/26))
 
 ## [0.3.0] - 2023-03-27
 

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -26,8 +26,8 @@ import rasterio
 from shapely.geometry import mapping, box, shape as make_shape
 from pystac import Item
 
-from stactools.cop_dem import constants as co
 from stactools.core.io import ReadHrefModifier
+from stactools.cop_dem import constants as co
 
 
 def create_item(

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -21,13 +21,13 @@ from pystac.extensions.raster import (
     Sampling,
 )
 from pystac.media_type import MediaType
-from stactools.core.io import ReadHrefModifier
 
 import rasterio
 from shapely.geometry import mapping, box, shape as make_shape
 from pystac import Item
 
 from stactools.cop_dem import constants as co
+from stactools.core.io import ReadHrefModifier
 
 
 def create_item(

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -21,14 +21,12 @@ from pystac.extensions.raster import (
     Sampling,
 )
 from pystac.media_type import MediaType
-from shapely.geometry import box, mapping, shape as make_shape
 from stactools.core.io import ReadHrefModifier
 
 import rasterio
-from shapely.geometry import mapping, box
+from shapely.geometry import mapping, box, shape as make_shape
 from pystac import Item
 
-from stactools.core.io import ReadHrefModifier
 from stactools.cop_dem import constants as co
 
 

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -21,6 +21,8 @@ from pystac.extensions.raster import (
     Sampling,
 )
 from pystac.media_type import MediaType
+from shapely.geometry import box, mapping, shape as make_shape
+from stactools.core.io import ReadHrefModifier
 
 import rasterio
 from shapely.geometry import mapping, box
@@ -112,6 +114,9 @@ def create_item(
     projection.epsg = co.COP_DEM_EPSG
     projection.transform = transform[0:6]
     projection.shape = shape
+
+    centroid = make_shape(item.geometry).centroid
+    projection.centroid = {"lat": centroid.y, "lon": centroid.x}
 
     grid = GridExtension.ext(item, add_if_missing=True)
     grid.code = f"CDEM-{northing}{easting}"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -126,6 +126,8 @@ class StacTest(TestCase):
             0.00125, 0.0, -115.000625, 0.0, -0.0008333333333333334,
             54.000416666666666
         ])
+        self.assertEqual(round(projection.centroid["lat"], 5), 53.50042)
+        self.assertEqual(round(projection.centroid["lon"], 5), -114.50062)
 
         grid = GridExtension.ext(item)
         self.assertEqual(grid.code, "CDEM-N53W115")


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

Adds proj:centroid property to Items. This will allow geoaggregations to be used in OpenSearch and Elasticsearch.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
