### PR TITLE
round proj centroid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2023-04-14
+
+### Changed
+
+- Round `proj:centroid` values to one decimal place, since they'll always be in 0.5 degree increments([#28](https://github.com/stactools-packages/cop-dem/pull/28))
+
 ## [0.4.0] - 2023-04-14
 
 ## Added
@@ -48,7 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - remove python 3.7 support
 
-[Unreleased]: https://github.com/stactools-packages/cop-dem/compare/v0.4.0..main
+[Unreleased]: https://github.com/stactools-packages/cop-dem/compare/v0.4.1..main
+[0.4.1]: https://github.com/stactools-packages/cop-dem/compare/v0.4.0..v0.4.1
 [0.4.0]: https://github.com/stactools-packages/cop-dem/compare/v0.3.0..v0.4.0
 [0.3.0]: https://github.com/stactools-packages/cop-dem/compare/v0.2.0..v0.3.0
 [0.2.0]: https://github.com/stactools-packages/cop-dem/compare/v0.1.1..v0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools[s3] >= 0.4.0
+    stactools[s3] >= 0.4.1
 
 [options.packages.find]
 where = src

--- a/src/stactools/cop_dem/__init__.py
+++ b/src/stactools/cop_dem/__init__.py
@@ -8,4 +8,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_cop_dem_command)
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -114,7 +114,10 @@ def create_item(
     projection.shape = shape
 
     centroid = make_shape(item.geometry).centroid
-    projection.centroid = {"lat": round(centroid.y, 1), "lon": round(centroid.x, 1)}
+    projection.centroid = {
+        "lat": round(centroid.y, 1),
+        "lon": round(centroid.x, 1)
+    }
 
     grid = GridExtension.ext(item, add_if_missing=True)
     grid.code = f"CDEM-{northing}{easting}"

--- a/src/stactools/cop_dem/stac.py
+++ b/src/stactools/cop_dem/stac.py
@@ -114,7 +114,7 @@ def create_item(
     projection.shape = shape
 
     centroid = make_shape(item.geometry).centroid
-    projection.centroid = {"lat": centroid.y, "lon": centroid.x}
+    projection.centroid = {"lat": round(centroid.y, 1), "lon": round(centroid.x, 1)}
 
     grid = GridExtension.ext(item, add_if_missing=True)
     grid.code = f"CDEM-{northing}{easting}"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -126,8 +126,8 @@ class StacTest(TestCase):
             0.00125, 0.0, -115.000625, 0.0, -0.0008333333333333334,
             54.000416666666666
         ])
-        self.assertEqual(round(projection.centroid["lat"], 5), 53.50042)
-        self.assertEqual(round(projection.centroid["lon"], 5), -114.50062)
+        self.assertEqual(round(projection.centroid["lat"], 5), 53.5)
+        self.assertEqual(round(projection.centroid["lon"], 5), -114.5)
 
         grid = GridExtension.ext(item)
         self.assertEqual(grid.code, "CDEM-N53W115")


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

- Round proj:centroid values, since they're always in 0.5 increments
- prep for 0.4.1 release

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
